### PR TITLE
feat: Clarity v4 enhancements across all 17 contracts

### DIFF
--- a/time-banking/contracts/analytics-tracker.clar
+++ b/time-banking/contracts/analytics-tracker.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for time-series data
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u11001))
 
@@ -53,9 +54,23 @@
             (update-user-activity receiver day amount false))
         (var-set total-exchanges (+ (var-get total-exchanges) u1))
         (var-set total-volume (+ (var-get total-volume) amount))
+        (print {
+            event: "exchange-recorded",
+            skill-id: skill-id,
+            provider: provider,
+            receiver: receiver,
+            amount: amount,
+            timestamp: stacks-block-time
+        })
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
+(define-read-only (get-current-timestamp)
+    (ok stacks-block-time))
+
 (define-read-only (get-daily-metrics (day uint))
     (ok (map-get? daily-metrics day)))
 

--- a/time-banking/contracts/automation-scheduler.clar
+++ b/time-banking/contracts/automation-scheduler.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for scheduling
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u6001))
 (define-constant ERR_NOT_FOUND (err u6002))
@@ -47,6 +48,15 @@
             amount: amount
         })
         (var-set schedule-counter schedule-id)
+        (print {
+            event: "schedule-created",
+            schedule-id: schedule-id,
+            owner: tx-sender,
+            recipient: recipient,
+            interval: interval,
+            next-execution: (+ stacks-block-time interval),
+            created-at: stacks-block-time
+        })
         (ok schedule-id)))
 
 (define-public (execute-schedule (schedule-id uint))
@@ -66,6 +76,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-schedule (schedule-id uint))
     (ok (map-get? schedules schedule-id)))
 

--- a/time-banking/contracts/dispute-arbitration.clar
+++ b/time-banking/contracts/dispute-arbitration.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for voting deadlines and evidence submission
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u4001))
 (define-constant ERR_NOT_FOUND (err u4002))
@@ -139,6 +140,21 @@
             (ok outcome))))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
+(define-read-only (is-voting-open (dispute-id uint))
+    (match (map-get? disputes dispute-id)
+        dispute (ok (and
+            (>= stacks-block-time (get evidence-deadline dispute))
+            (< stacks-block-time (get voting-deadline dispute))))
+        ERR_NOT_FOUND))
+
+(define-read-only (is-evidence-period-open (dispute-id uint))
+    (match (map-get? disputes dispute-id)
+        dispute (ok (< stacks-block-time (get evidence-deadline dispute)))
+        ERR_NOT_FOUND))
+
 (define-read-only (get-dispute (dispute-id uint))
     (ok (map-get? disputes dispute-id)))
 

--- a/time-banking/contracts/emergency-controls.clar
+++ b/time-banking/contracts/emergency-controls.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for timelocks
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u9001))
 (define-constant ERR_NOT_FOUND (err u9002))
@@ -80,6 +81,17 @@
         (ok operation-id)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
+(define-read-only (is-operation-executable (operation-id uint))
+    (match (map-get? timelocked-operations operation-id)
+        op (ok (and (not (get executed op)) (>= stacks-block-time (get execute-after op))))
+        ERR_NOT_FOUND))
+
+(define-read-only (get-operation (operation-id uint))
+    (ok (map-get? timelocked-operations operation-id)))
+
 (define-read-only (is-globally-paused)
     (ok (var-get global-pause)))
 

--- a/time-banking/contracts/escrow-manager.clar
+++ b/time-banking/contracts/escrow-manager.clar
@@ -2,6 +2,9 @@
 ;; Manages credit escrow for secure time-banking exchanges
 ;; Uses stacks-block-time for expiration and Clarity 4 restrict-assets?
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Error Codes
 (define-constant ERR_UNAUTHORIZED (err u5001))
 (define-constant ERR_NOT_FOUND (err u5002))
@@ -261,6 +264,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-escrow-info (escrow-id uint))
     (map-get? escrows escrow-id))
 

--- a/time-banking/contracts/exchange-manager.clar
+++ b/time-banking/contracts/exchange-manager.clar
@@ -2,6 +2,9 @@
 ;; Manages time-skill exchange requests, agreements, and completions
 ;; Uses stacks-block-time for scheduling and deadlines
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Error Codes
 (define-constant ERR_UNAUTHORIZED (err u3001))
 (define-constant ERR_NOT_FOUND (err u3002))
@@ -258,6 +261,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-exchange-info (exchange-id uint))
     (map-get? exchanges exchange-id))
 

--- a/time-banking/contracts/governance.clar
+++ b/time-banking/contracts/governance.clar
@@ -2,6 +2,9 @@
 ;; Protocol governance with proposal creation, voting, and execution
 ;; Uses stacks-block-time for voting periods and timelock
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Error Codes
 (define-constant ERR_UNAUTHORIZED (err u6001))
 (define-constant ERR_NOT_FOUND (err u6002))
@@ -234,6 +237,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-proposal (proposal-id uint))
     (map-get? proposals proposal-id))
 

--- a/time-banking/contracts/insurance-pool.clar
+++ b/time-banking/contracts/insurance-pool.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for claim filing and processing
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u5001))
 (define-constant ERR_NOT_FOUND (err u5002))
@@ -93,6 +94,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-contributor-info (contributor principal))
     (ok (map-get? contributors contributor)))
 

--- a/time-banking/contracts/multi-sig-wallet.clar
+++ b/time-banking/contracts/multi-sig-wallet.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for timelocks
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u10001))
 (define-constant ERR_NOT_FOUND (err u10002))
@@ -83,6 +84,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-proposal (proposal-id uint))
     (ok (map-get? proposals proposal-id)))
 

--- a/time-banking/contracts/referral-program.clar
+++ b/time-banking/contracts/referral-program.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for tracking
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u8001))
 (define-constant ERR_NOT_FOUND (err u8002))
@@ -63,6 +64,9 @@
             (ok true))))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-user-data (user principal))
     (ok (map-get? user-referrals user)))
 

--- a/time-banking/contracts/reputation-system.clar
+++ b/time-banking/contracts/reputation-system.clar
@@ -2,6 +2,9 @@
 ;; Advanced reputation calculation and badge management
 ;; Uses stacks-block-time for time-weighted reputation scoring
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Error Codes
 (define-constant ERR_UNAUTHORIZED (err u4001))
 (define-constant ERR_NOT_FOUND (err u4002))
@@ -292,6 +295,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-reputation-score (user principal))
     (map-get? reputation-scores user))
 

--- a/time-banking/contracts/rewards-distributor.clar
+++ b/time-banking/contracts/rewards-distributor.clar
@@ -12,6 +12,7 @@
 (define-constant ERR_NOT_ELIGIBLE (err u7007))
 
 ;; Configuration
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant REWARD_PERIOD u2592000) ;; 30 days
 (define-constant MIN_ACTIVITY_SCORE u10)
@@ -244,6 +245,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-period-info (period-id uint))
     (map-get? reward-periods period-id))
 

--- a/time-banking/contracts/skill-certification-nft.clar
+++ b/time-banking/contracts/skill-certification-nft.clar
@@ -9,6 +9,7 @@
 (define-non-fungible-token skill-certification uint)
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u2001))
 (define-constant ERR_NOT_FOUND (err u2002))
@@ -108,6 +109,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-certification-info (token-id uint))
     (ok (map-get? certification-data token-id)))
 

--- a/time-banking/contracts/skill-matching-engine.clar
+++ b/time-banking/contracts/skill-matching-engine.clar
@@ -3,6 +3,7 @@
 ;; Uses stacks-block-time for match proposals
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u7001))
 (define-constant ERR_NOT_FOUND (err u7002))
@@ -94,6 +95,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-demand (requester principal) (skill-id uint))
     (ok (map-get? skill-demand { requester: requester, skill-id: skill-id })))
 

--- a/time-banking/contracts/skill-registry.clar
+++ b/time-banking/contracts/skill-registry.clar
@@ -2,6 +2,9 @@
 ;; Manages skill registration, verification, and categorization
 ;; Uses contract-hash? for verified skill templates
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Error Codes
 (define-constant ERR_UNAUTHORIZED (err u2001))
 (define-constant ERR_NOT_FOUND (err u2002))
@@ -209,6 +212,9 @@
         (ok true)))
 
 ;; Read-Only Functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-skill-info (user principal) (skill-id uint))
     (map-get? skills {user: user, skill-id: skill-id}))
 

--- a/time-banking/contracts/time-bank-core.clar
+++ b/time-banking/contracts/time-bank-core.clar
@@ -2,6 +2,9 @@
 ;; Manages user registration, time credit balances, and core banking functionality
 ;; Refactored to use Clarity 4 features: stacks-block-time, improved type safety
 
+;; Version
+(define-constant CONTRACT_VERSION "4.0.0")
+
 ;; Constants and Error Codes
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u1001))
@@ -243,6 +246,9 @@
 
 (define-read-only (get-user-balance (user principal))
     (ok (get-balance user)))
+
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
 
 (define-read-only (get-contract-owner)
     (ok CONTRACT_OWNER))

--- a/time-banking/contracts/time-token-ft.clar
+++ b/time-banking/contracts/time-token-ft.clar
@@ -9,6 +9,7 @@
 (define-fungible-token time-token)
 
 ;; constants
+(define-constant CONTRACT_VERSION "4.0.0")
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_UNAUTHORIZED (err u3001))
 (define-constant ERR_INSUFFICIENT_BALANCE (err u3002))
@@ -91,6 +92,12 @@
                 staked-at: stacks-block-time,
                 last-reward-claim: stacks-block-time,
                 total-rewards: (get total-rewards current-stake)
+            })
+            (print {
+                event: "tokens-staked",
+                staker: tx-sender,
+                amount: amount,
+                staked-at: stacks-block-time
             }))
         (ok true)))
 
@@ -111,6 +118,9 @@
         (ok true)))
 
 ;; read only functions
+(define-read-only (get-contract-version)
+    (ok CONTRACT_VERSION))
+
 (define-read-only (get-allowance (owner principal) (spender principal))
     (ok (get-allowance-or-default owner spender)))
 


### PR DESCRIPTION
## Summary

- Adds `CONTRACT_VERSION "4.0.0"` constant to all 17 contracts where it was missing
- Adds `get-contract-version` read-only function to all 17 contracts for on-chain version querying
- Enhances several contracts with additional Clarity v4 improvements: structured print events with `stacks-block-time`, block-time based expiry/deadline query helpers, and timestamp fields in events

## Changes per contract

- **time-bank-core**: VERSION constant + version getter
- **time-token-ft**: VERSION constant + version getter + `tokens-staked` print event with `staked-at` timestamp
- **analytics-tracker**: VERSION + version getter + `get-current-timestamp` helper + `exchange-recorded` print event
- **automation-scheduler**: VERSION + version getter + `schedule-created` print event with `created-at` and `next-execution`
- **dispute-arbitration**: VERSION + version getter + `is-voting-open` and `is-evidence-period-open` block-time query helpers
- **emergency-controls**: VERSION + version getter + `is-operation-executable` timelock query + `get-operation` helper
- **escrow-manager**: VERSION + version getter
- **exchange-manager**: VERSION + version getter
- **governance**: VERSION + version getter
- **insurance-pool**: VERSION + version getter
- **multi-sig-wallet**: VERSION + version getter
- **referral-program**: VERSION + version getter
- **reputation-system**: VERSION + version getter
- **rewards-distributor**: VERSION + version getter
- **skill-certification-nft**: VERSION + version getter
- **skill-matching-engine**: VERSION + version getter
- **skill-registry**: VERSION + version getter

## Test plan

- [x] `clarinet check` passes with 17/17 contracts (96 warnings, 0 errors)
- [ ] Verify `get-contract-version` returns `"4.0.0"` for each contract in tests
- [ ] Confirm new print events are captured by chainhook subscriptions
- [ ] Validate block-time deadline query helpers return correct booleans